### PR TITLE
added entry for actual user in visudo

### DIFF
--- a/tpn.sh
+++ b/tpn.sh
@@ -379,7 +379,11 @@ disconnect() {
 # Add sudoers entry
 # --------------------
 visudo() {
-  user=$(id -un)
+  if [ -n "$USER" ]; then
+    user="$USER"
+  else
+    user=$(id -un)
+  fi
   file="/etc/sudoers.d/tpn"
   grey "Creating sudoers entry for wg and wg-quick..."
   [ -f "$file" ] && sudo rm -f "$file"


### PR DESCRIPTION
The `visudo() ` function was creating sudoers entries for "root"  and doesn't create for  actual user when called from elevated contexts like GUI applications running with administrator privileges.